### PR TITLE
Fixed BigNumber sometimes returned as float instead of int

### DIFF
--- a/src/ShortUuid.php
+++ b/src/ShortUuid.php
@@ -134,7 +134,7 @@ final class ShortUuid
             $number = $number->divide($this->alphabetLength);
             $digit = $previousNumber->mod($this->alphabetLength);
 
-            $output .= $this->alphabet[$digit->getValue()];
+            $output .= $this->alphabet[(int)$digit->getValue()];
         }
 
         return $output;


### PR DESCRIPTION
Sometimes `ShortUuid->encode()` throws because `BigNumber->getValue()` returns 48.0000000000 instead of 48. I didn't found the reason of this erroneous conversion, my unit test attempt was not successful to reproduce it.


Additional information:
- The problematic UUID v4 is `7ae31a0e-7238-11e8-b29b-c83a35dab7f4`

![an exception has been thrown](https://user-images.githubusercontent.com/32240357/41510323-bb1ed7bc-7262-11e8-8c74-846521ff737d.png)
