### PR TITLE
PHP 8.4: Avoid deprecated notice

### DIFF
--- a/src/ShortUuid.php
+++ b/src/ShortUuid.php
@@ -31,7 +31,7 @@ final class ShortUuid
     /**
      * @param array|null $alphabet
      */
-    public function __construct(array $alphabet = null)
+    public function __construct(?array $alphabet = null)
     {
         if (null !== $alphabet) {
             $this->setAlphabet($alphabet);


### PR DESCRIPTION
> Deprecated: PascalDeVink\ShortUuid\ShortUuid::__construct(): Implicitly marking parameter $alphabet as nullable is deprecated, the explicit nullable type must be used instead in vendor/pascaldevink/shortuuid/src/ShortUuid.php on line 34